### PR TITLE
LIBRARY-204 - Add “Available Books” endpoint

### DIFF
--- a/src/controllers/bookcontroller.ts
+++ b/src/controllers/bookcontroller.ts
@@ -124,3 +124,18 @@ export const getRecommendations = (_req: Request, res: Response): void => {
         });
     }
 };
+
+export const availableBooks = (_req: Request, res: Response): void => {
+    try {
+        const availableBooks = bookService.getAvailableBooks();
+        res.status(HTTP_STATUS.OK).json({
+            message: "Available books",
+            data: availableBooks,
+            count: availableBooks.length,
+        });
+    } catch (error) {
+        res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).json({
+            message: "Error retrieving available books",
+        });
+    }
+};

--- a/src/routes/bookRoutes.ts
+++ b/src/routes/bookRoutes.ts
@@ -7,6 +7,8 @@ import {
     borrowBook,
     returnBook,
     getRecommendations,
+    availableBooks,
+    
 } from "../controllers/bookcontroller";
 
 const router: Router = Router();
@@ -21,5 +23,6 @@ router.delete("/:id", deleteBook);
 router.post("/:id/borrow", borrowBook);
 router.post("/:id/return", returnBook);
 router.get("/recommendations", getRecommendations);
+router.get("/available", availableBooks);
 
 export default router;

--- a/src/services/bookService.ts
+++ b/src/services/bookService.ts
@@ -209,3 +209,12 @@ export const returnBook = (id: string): Book | null => {
 export const getRecommendations = (): Book[] => {
     return structuredClone(books.slice(0, 3));
 };
+
+/**
+ * Gets all books that are currently available (not borrowed).
+ * 
+ * @returns {Book[]} Array of books where isBorrowed is false
+ */
+export const getAvailableBooks = (): Book[] => {
+    return structuredClone(books.filter(book => book.isBorrowed === false));
+};


### PR DESCRIPTION
### **What I did**

Implemented the GET `/api/v1/books/available `flow so Marketing can pull only books that are not currently borrowed. Kept it simple and followed the existing patterns in bookService and the controller.

### **Why I did this**

The Ticket LIBRARY-204 asks for an endpoint to return only available books (where isBorrowed === false) using the same response format as the main books endpoint, plus a total count.


### **Key Changes:**


**Service:** Added getAvailableBooks() to src/services/bookService.ts

- Filters books in the array by isBorrowed === false
- 
- Returns a cloned array (structuredClone) 

**Controller:** Added availableBooks to src/controllers/bookcontroller.ts

- Calls the service
- 
- Responds with { message, data, count }
- 
- Uses HTTP_STATUS.OK (200) on success, and HTTP_STATUS.INTERNAL_SERVER_ERROR on failure

**Routes:** Route already existed in bookRoutes.ts:

- router.get("/available", availableBooks)
### 

**Behavior of  endbpoint** 


Route: GET /api/v1/books/available
Status: 200 OK on success

Example response:
<img width="471" height="562" alt="Screenshot From 2025-09-18 18-21-14" src="https://github.com/user-attachments/assets/f7ed1137-61de-40bb-817f-5d65d4a3fed4" />



