### PR TITLE
LIBRARY-205 Validate book creation

### DIFF
--- a/src/controllers/bookcontroller.ts
+++ b/src/controllers/bookcontroller.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express";
 import { HTTP_STATUS } from "../constants/httpConstants";
 import * as bookService from "../services/bookService";
+import { Book } from "../models/bookModel";
 
 export const getAllBooks = (_req: Request, res: Response): void => {
     try {
@@ -18,8 +19,44 @@ export const getAllBooks = (_req: Request, res: Response): void => {
 
 export const addBook = (req: Request, res: Response): void => {
     try {
-        const newBook = req.body;
-        const createdBook = bookService.addBook(newBook);
+        // I need to get the fields from the request body
+        const { title, author, genre } = req.body;
+        
+        // I trim whitespace before checking if they're valid
+        const trimmedTitle = title?.trim();
+        const trimmedAuthor = author?.trim();
+        const trimmedGenre = genre?.trim();
+        
+        // I check each field to make sure it exists and isn't empty
+        if (!trimmedTitle) {
+            res.status(HTTP_STATUS.BAD_REQUEST).json({
+                message: "Title is required and cannot be empty",
+            });
+            return;
+        }
+        
+        if (!trimmedAuthor) {
+            res.status(HTTP_STATUS.BAD_REQUEST).json({
+                message: "Author is required and cannot be empty",
+            });
+            return;
+        }
+        
+        if (!trimmedGenre) {
+            res.status(HTTP_STATUS.BAD_REQUEST).json({
+                message: "Genre is required and cannot be empty",
+            });
+            return;
+        }
+        
+        // I create the book data with trimmed values
+        const bookData: Pick<Book, "title" | "author" | "genre"> = {
+            title: trimmedTitle,
+            author: trimmedAuthor,
+            genre: trimmedGenre,
+        };
+        
+        const createdBook = bookService.addBook(bookData);
         res.status(HTTP_STATUS.CREATED).json({
             message: "Book added",
             data: createdBook,

--- a/src/controllers/bookcontroller.ts
+++ b/src/controllers/bookcontroller.ts
@@ -124,3 +124,18 @@ export const getRecommendations = (_req: Request, res: Response): void => {
         });
     }
 };
+
+export const availableBooks = (_req: Request, res: Response): void => {
+    try {
+        const availableBooks = bookService.getAvailableBooks();
+        res.status(HTTP_STATUS.OK).json({
+            message: "Available books",
+            data: availableBooks,
+            count: availableBooks.length,
+        });
+    } catch (error) {
+        res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).json({
+            message: "Error retrieving available books",
+        });
+    }
+};

--- a/src/routes/bookRoutes.ts
+++ b/src/routes/bookRoutes.ts
@@ -7,6 +7,8 @@ import {
     borrowBook,
     returnBook,
     getRecommendations,
+    availableBooks,
+    
 } from "../controllers/bookcontroller";
 
 const router: Router = Router();
@@ -21,5 +23,6 @@ router.delete("/:id", deleteBook);
 router.post("/:id/borrow", borrowBook);
 router.post("/:id/return", returnBook);
 router.get("/recommendations", getRecommendations);
+router.get("/available", availableBooks);
 
 export default router;

--- a/src/services/bookService.ts
+++ b/src/services/bookService.ts
@@ -209,3 +209,12 @@ export const returnBook = (id: string): Book | null => {
 export const getRecommendations = (): Book[] => {
     return structuredClone(books.slice(0, 3));
 };
+
+/**
+ * Gets all books that are currently available (not borrowed).
+ * 
+ * @returns {Book[]} Array of books where isBorrowed is false
+ */
+export const getAvailableBooks = (): Book[] => {
+    return structuredClone(books.filter(book => book.isBorrowed === false));
+};


### PR DESCRIPTION
### **What I did**

Added simple, type-safe validation to the book creation endpoint so we don’t save incomplete records. Kept it basic and followed our existing controller/service style.

### **Why**

Ticket LIBRARY-205 asks us to validate title, author, and genre, trim whitespace first, and return clear errors with proper status codes. This prevents bad data from getting into the list.


### **Key changes**

- Controller: src/controllers/bookcontroller.ts

- Switched to destructuring: const { title, author, genre } = req.body

- Trimmed each field before checks

- Added simple required + non-empty validation for each field

- Returned 400 Bad Request with a descriptive message when a field is missing/empty

### 

**Endpoint behavior**

Route: POST /api/v1/books
Status (success): 201 Created
Status (validation error): 400 Bad Request


Examples:


**Missing Value** (400 Failed)

<img width="1177" height="302" alt="Screenshot From 2025-09-18 18-46-44" src="https://github.com/user-attachments/assets/9202ab69-f006-4580-b0e8-d0bdbe19612e" />


**Successful addBook**  (201 Success)

<img width="1177" height="302" alt="Screenshot From 2025-09-18 18-46-44" src="https://github.com/user-attachments/assets/bcd50595-fab2-4ed2-bc15-ac73de0307af" />
